### PR TITLE
fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test:
 
 .PHONY: build
 build:
-	pipenv lock -r > requirements.txt
+	pipenv requirements > requirements.txt
 	docker build -f build/Dockerfile . -t ${IMG}
 	rm requirements.txt
 


### PR DESCRIPTION
pipenv lock -r no longer supported
replaced by 'pipenv requirements'

Signed-off-by: Doron Chen <cdoron@il.ibm.com>